### PR TITLE
Fix save post api

### DIFF
--- a/Blog/Blog/Controllers/PostControllers.cs
+++ b/Blog/Blog/Controllers/PostControllers.cs
@@ -1,5 +1,6 @@
 ﻿using Blog.Database.Interfaces;
 using Blog.DTO;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
@@ -93,7 +94,7 @@ public class PostController : ControllerBase
         return await postRepository.RestoreDeletedPost(id);
     }
 
-    [Authorize]
+    [Authorize(AuthenticationSchemes = $"{CookieAuthenticationDefaults.AuthenticationScheme},Bearer")]
     [HttpPost("savePost")]
     [Produces("text/plain")]
     [SwaggerOperation(OperationId = "savePost")]

--- a/Blog/Blog/Program.cs
+++ b/Blog/Blog/Program.cs
@@ -33,7 +33,7 @@ builder.Services.AddScoped<AuthenticationStateProvider, PersistingRevalidatingAu
 var baseUrl = builder.Configuration["BaseUrl"];
 var databaseSource = builder.Configuration["DatabaseSource"];
 var portNumber = int.Parse(builder.Configuration["PortNumber"]);
-var savePostApi = builder.Configuration["SavePostApi"];
+var savePostApi = builder.Configuration["SavePostAPI"];
 var authority = builder.Configuration["Auth0_Domain"];
 
 
@@ -79,21 +79,39 @@ builder.Services.AddScoped<IApiClient>(sp =>
 });
 
 
+//builder.Services.AddAuth0WebAppAuthentication(options =>
+//{
+//    options.Domain = builder.Configuration["Auth0:Domain"];
+//    options.ClientId = builder.Configuration["Auth0:ClientId"];
+//});
+
+//builder.Services.AddAuthentication(options =>
+//{
+//    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+//    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+//}).AddJwtBearer(options =>
+//{
+//    options.Authority = authority;
+//    options.Audience = savePostApi;
+//});
+
+// Auth0 for Web App (cookie-based)
 builder.Services.AddAuth0WebAppAuthentication(options =>
 {
     options.Domain = builder.Configuration["Auth0:Domain"];
     options.ClientId = builder.Configuration["Auth0:ClientId"];
 });
 
-builder.Services.AddAuthentication(options =>
-{
-    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-}).AddJwtBearer(options =>
-{
-    options.Authority = authority;
-    options.Audience = savePostApi;
-});
+// Add default cookie auth scheme for WebApp
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme);
+
+// Add JWT Bearer auth scheme for API
+builder.Services.AddAuthentication()
+    .AddJwtBearer("Bearer", options =>
+    {
+        options.Authority = authority;
+        options.Audience = savePostApi;
+    });
 
 builder.Services.AddMudServices();
 


### PR DESCRIPTION
Updated PostControllers.cs to support cookie and bearer authentication schemes. Added SavePost method for handling PostDTO submissions.

Corrected configuration key for save post API in Program.cs and transitioned to a new authentication setup. Removed previous JWT Bearer configuration and added cookie-based authentication for web apps, along with a new JWT Bearer scheme for APIs.